### PR TITLE
Fixed segmentation fault for using C++11 Threads

### DIFF
--- a/Includes/Core/Utils/Parallel-Impl.h
+++ b/Includes/Core/Utils/Parallel-Impl.h
@@ -87,11 +87,12 @@ namespace CubbyFlow
             });
 
             tbb::task::enqueue(*tbbNode);
+            return task.get_future();
 
 #elif defined(CUBBYFLOW_TASKING_CPP11THREAD)
             return std::async(std::launch::async, fn);
 #else
-            fn();
+            return std::async(std::launch::deferred, fn);
 #endif
         }
 


### PR DESCRIPTION
I forgot to return a future for TBB and Cpp11 Threads.
sry. fixed now.