### PR TITLE
Fix link error problem in MemPerfTest (#4)

### DIFF
--- a/Tests/MemPerfTests/FDMICCGSolver3Tests.cpp
+++ b/Tests/MemPerfTests/FDMICCGSolver3Tests.cpp
@@ -5,6 +5,8 @@
 #include <Core/FDM/FDMLinearSystem3.h>
 #include <Core/Solver/FDM/FDMICCGSolver3.h>
 
+#include <iostream>
+
 using namespace CubbyFlow;
 
 TEST(FDMICCGSolver3, Memory)
@@ -25,5 +27,5 @@ TEST(FDMICCGSolver3, Memory)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Mem usage: %f %s.\n", msg.first, msg.second.c_str());
+    std::cout << "Mem usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
 }

--- a/Tests/MemPerfTests/FDMICCGSolver3Tests.cpp
+++ b/Tests/MemPerfTests/FDMICCGSolver3Tests.cpp
@@ -5,8 +5,6 @@
 #include <Core/FDM/FDMLinearSystem3.h>
 #include <Core/Solver/FDM/FDMICCGSolver3.h>
 
-#include <iostream>
-
 using namespace CubbyFlow;
 
 TEST(FDMICCGSolver3, Memory)
@@ -27,5 +25,5 @@ TEST(FDMICCGSolver3, Memory)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Mem usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
+    PrintMemReport(msg.first, msg.second);
 }

--- a/Tests/MemPerfTests/FLIPSolver3Tests.cpp
+++ b/Tests/MemPerfTests/FLIPSolver3Tests.cpp
@@ -5,6 +5,8 @@
 #include <Core/Animation/Frame.h>
 #include <Core/Solver/Hybrid/FLIP/FLIPSolver3.h>
 
+#include <iostream>
+
 using namespace CubbyFlow;
 
 TEST(FLIPSolver3, Memory)
@@ -21,9 +23,7 @@ TEST(FLIPSolver3, Memory)
 
     const auto msg1 = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Start mem. usage: %f %s.\n",
-        msg1.first,
-        msg1.second.c_str());
+    std::cout << "Start mem. usage: " << msg1.first << ' ' << msg1.second.c_str() << ".\n";
 
     solver->Update(Frame(1, 0.01));
 
@@ -31,5 +31,5 @@ TEST(FLIPSolver3, Memory)
 
     const auto msg2 = MakeReadableByteSize(mem2 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single update mem. usage: %f %s.\n", msg2.first, msg2.second.c_str());
+    std::cout << "Single update mem. usage: " << msg2.first << ' ' << msg2.second.c_str() << ".\n";
 }

--- a/Tests/MemPerfTests/FLIPSolver3Tests.cpp
+++ b/Tests/MemPerfTests/FLIPSolver3Tests.cpp
@@ -5,8 +5,6 @@
 #include <Core/Animation/Frame.h>
 #include <Core/Solver/Hybrid/FLIP/FLIPSolver3.h>
 
-#include <iostream>
-
 using namespace CubbyFlow;
 
 TEST(FLIPSolver3, Memory)
@@ -23,7 +21,7 @@ TEST(FLIPSolver3, Memory)
 
     const auto msg1 = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Start mem. usage: " << msg1.first << ' ' << msg1.second.c_str() << ".\n";
+    PrintMemReport(msg1.first, msg1.second);
 
     solver->Update(Frame(1, 0.01));
 
@@ -31,5 +29,5 @@ TEST(FLIPSolver3, Memory)
 
     const auto msg2 = MakeReadableByteSize(mem2 - mem0);
 
-    std::cout << "Single update mem. usage: " << msg2.first << ' ' << msg2.second.c_str() << ".\n";
+    PrintMemReport(msg2.first, msg2.second);
 }

--- a/Tests/MemPerfTests/GridFluidSolver3Tests.cpp
+++ b/Tests/MemPerfTests/GridFluidSolver3Tests.cpp
@@ -5,8 +5,6 @@
 #include <Core/Animation/Frame.h>
 #include <Core/Solver/Grid/GridFluidSolver3.h>
 
-#include <iostream>
-
 using namespace CubbyFlow;
 
 TEST(GridFluidSolver3, Memory)
@@ -23,7 +21,7 @@ TEST(GridFluidSolver3, Memory)
 
     const auto msg1 = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Start mem. usage: " << msg1.first << ' ' << msg1.second.c_str() << ".\n";
+    PrintMemReport(msg1.first, msg1.second);
 
     solver->Update(Frame(1, 0.01));
 
@@ -31,5 +29,5 @@ TEST(GridFluidSolver3, Memory)
 
     const auto msg2 = MakeReadableByteSize(mem2 - mem0);
 
-    std::cout << "Single update mem. usage: " << msg2.first << ' ' << msg2.second.c_str() << ".\n";
+    PrintMemReport(msg2.first, msg2.second);
 }

--- a/Tests/MemPerfTests/GridFluidSolver3Tests.cpp
+++ b/Tests/MemPerfTests/GridFluidSolver3Tests.cpp
@@ -5,6 +5,8 @@
 #include <Core/Animation/Frame.h>
 #include <Core/Solver/Grid/GridFluidSolver3.h>
 
+#include <iostream>
+
 using namespace CubbyFlow;
 
 TEST(GridFluidSolver3, Memory)
@@ -21,7 +23,7 @@ TEST(GridFluidSolver3, Memory)
 
     const auto msg1 = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Start mem. usage: %f %s.\n", msg1.first, msg1.second.c_str());
+    std::cout << "Start mem. usage: " << msg1.first << ' ' << msg1.second.c_str() << ".\n";
 
     solver->Update(Frame(1, 0.01));
 
@@ -29,5 +31,5 @@ TEST(GridFluidSolver3, Memory)
 
     const auto msg2 = MakeReadableByteSize(mem2 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single update mem. usage: %f %s.\n", msg2.first, msg2.second.c_str());
+    std::cout << "Single update mem. usage: " << msg2.first << ' ' << msg2.second.c_str() << ".\n";
 }

--- a/Tests/MemPerfTests/GridFractionalSinglePhasePressureSolver3Tests.cpp
+++ b/Tests/MemPerfTests/GridFractionalSinglePhasePressureSolver3Tests.cpp
@@ -6,6 +6,8 @@
 #include <Core/Grid/CellCenteredScalarGrid3.h>
 #include <Core/Solver/Grid/GridFractionalSinglePhasePressureSolver3.h>
 
+#include <iostream>
+
 using namespace CubbyFlow;
 
 namespace
@@ -58,7 +60,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullUncompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first, msg.second.c_str());
+    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed)
@@ -71,7 +73,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first, msg.second.c_str());
+    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed)
@@ -84,7 +86,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first, msg.second.c_str());
+    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed)
@@ -97,5 +99,5 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    CUBBYFLOW_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first, msg.second.c_str());
+    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
 }

--- a/Tests/MemPerfTests/GridFractionalSinglePhasePressureSolver3Tests.cpp
+++ b/Tests/MemPerfTests/GridFractionalSinglePhasePressureSolver3Tests.cpp
@@ -6,8 +6,6 @@
 #include <Core/Grid/CellCenteredScalarGrid3.h>
 #include <Core/Solver/Grid/GridFractionalSinglePhasePressureSolver3.h>
 
-#include <iostream>
-
 using namespace CubbyFlow;
 
 namespace
@@ -60,7 +58,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullUncompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
+    PrintMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed)
@@ -73,7 +71,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
+    PrintMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed)
@@ -86,7 +84,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
+    PrintMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed)
@@ -99,5 +97,5 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed)
 
     const auto msg = MakeReadableByteSize(mem1 - mem0);
 
-    std::cout << "Single solve mem. usage: " << msg.first << ' ' << msg.second.c_str() << ".\n";
+    PrintMemReport(msg.first, msg.second);
 }

--- a/Tests/MemPerfTests/MemPerfTestsUtils.cpp
+++ b/Tests/MemPerfTests/MemPerfTestsUtils.cpp
@@ -1,7 +1,13 @@
 #include "MemPerfTestsUtils.h"
 
+#include <iostream>
 #include <string>
 #include <utility>
+
+void PrintMemReport(size_t memUsage, const std::string& memMessage)
+{
+    std::cout << "Mem usage: " << memUsage << ' ' << memMessage << '\n';
+}
 
 std::pair<double, std::string> MakeReadableByteSize(size_t bytes)
 {

--- a/Tests/MemPerfTests/MemPerfTestsUtils.h
+++ b/Tests/MemPerfTests/MemPerfTestsUtils.h
@@ -5,31 +5,8 @@
 #include <utility>
 #include <vector>
 
-// gtest hack
-namespace testing
-{
-	namespace internal
-	{
-		enum GTestColor
-		{
-			COLOR_DEFAULT,
-			COLOR_RED,
-			COLOR_GREEN,
-			COLOR_YELLOW
-		};
-
-		extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
-	}
-}
-
 size_t GetCurrentRSS();
 
 std::pair<double, std::string> MakeReadableByteSize(size_t bytes);
-
-#define CUBBYFLOW_PRINT_INFO(fmt, ...) \
-	testing::internal::ColoredPrintf( \
-		testing::internal::COLOR_YELLOW,  "[   STAT   ] "); \
-	testing::internal::ColoredPrintf( \
-		testing::internal::COLOR_YELLOW, fmt, __VA_ARGS__); \
 
 #endif

--- a/Tests/MemPerfTests/MemPerfTestsUtils.h
+++ b/Tests/MemPerfTests/MemPerfTestsUtils.h
@@ -5,6 +5,8 @@
 #include <utility>
 #include <vector>
 
+void PrintMemReport(size_t memUsage, const std::string& memMessage);
+
 size_t GetCurrentRSS();
 
 std::pair<double, std::string> MakeReadableByteSize(size_t bytes);


### PR DESCRIPTION
If you have the latest version of googletest, you will get link errors when building the MemPerfTests project. This problem is caused by the ColoredPrintf function becoming a static function. This revision fixes it.