### PR TITLE
Tweak LGTM.com C/C++ analysis (#55)

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,7 @@
+path_classifiers:
+  library:
+    - Libraries
+  test:
+    - Tests
+  documentation:
+    - Documents

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![License](https://img.shields.io/badge/Licence-MIT-blue.svg)](https://github.com/utilForever/CubbyFlow-v0/blob/master/LICENSE) [![Build Status](https://travis-ci.org/utilForever/CubbyFlow-v0.svg?branch=master)](https://travis-ci.org/utilForever/CubbyFlow-v0/branches) [![Build status](https://ci.appveyor.com/api/projects/status/github/utilForever/CubbyFlow-v0?branch=master&svg=true)](https://ci.appveyor.com/project/utilForever/CubbyFlow-v0/branch/master) [![codecov](https://codecov.io/gh/utilForever/CubbyFlow-v0/branch/master/graph/badge.svg)](https://codecov.io/gh/utilForever/CubbyFlow-v0)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/742a769951a040788c89dc0af40d4405)](https://www.codacy.com/app/utilForever/CubbyFlow-v0?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=utilForever/CubbyFlow-v0&amp;utm_campaign=Badge_Grade)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/utilForever/CubbyFlow-v0.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/utilForever/CubbyFlow-v0/alerts/)
+[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/utilForever/CubbyFlow-v0.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/utilForever/CubbyFlow-v0/alerts/)
 
 <b>IMPORTANT: Most of the code in this repository is copied from [Jet Framework](https://github.com/doyubkim/fluid-engine-dev) and ["Fluid Engine Development" book](http://fluidenginedevelopment.org/) that was created by [Doyub Kim](https://twitter.com/doyub).</b>
 


### PR DESCRIPTION
After our discussion in https://github.com/utilForever/Hearthstonepp/issues/138, LGTM.com has now started analysing [this repository](https://lgtm.com/projects/g/utilForever/CubbyFlow-v0/snapshot/cd1057527404b92e815a742ae31ca88101e51328/files/?showExcluded=true).

No additional build configuration is needed (LGTM autodetects most build systems), but this `lgtm.yml` file makes sure that your library, test, and documentation code is correctly classified so that alerts in this code are not shown by default. They also don't count towards your code quality grade.

I've added the grade to your `README.md`; the grade will update as soon as LGTM has analysed a commit with this `lgtm.yml`. Considering that [most alerts are located in the `Libraries` directory](https://lgtm.com/projects/g/utilForever/CubbyFlow-v0/snapshot/cd1057527404b92e815a742ae31ca88101e51328/files/?showExcluded=true), I'm fairly sure your code quality grade will improve significantly after merging this PR :slightly_smiling_face: 